### PR TITLE
Specify maximum scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
   <title>Midpoint</title>
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" type="image/png" href="assets/favicon-96x96.png" sizes="96x96" />


### PR DESCRIPTION
iOS automatically zooms into the webpage when a text input's font size is <16px. Despite Google's new PAC Widget appropriately resizing text for mobile displays, iOS still zooms in which disrupts the user flow.

Setting a maximum scale might be a workaround to avoid this.